### PR TITLE
Native checksum protocol extension

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,1 +1,2 @@
-idf_component_register(SRCS "uart_nic.c" INCLUDE_DIRS ".")
+idf_component_register(SRCS "uart_nic.cpp" INCLUDE_DIRS ".")
+target_compile_options(${COMPONENT_LIB} PRIVATE -std=gnu++23)

--- a/main/esp_protocol/messages.hpp
+++ b/main/esp_protocol/messages.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <array>
+
+namespace esp {
+
+constexpr uint8_t REQUIRED_PROTOCOL_VERSION = 13;
+constexpr size_t INTRON_SIZE = 8;
+constexpr size_t SSID_LEN = 32;
+constexpr size_t MAC_SIZE = 6;
+using Intron = std::array<uint8_t, INTRON_SIZE>;
+constexpr Intron DEFAULT_INTRON = { 'U', 'N', 0, 1, 2, 3, 4, 5 };
+
+// note: Values 1-5 are deprecated and shouldn't be used
+enum class MessageType : uint8_t {
+    DEVICE_INFO_V2 = 0,
+    CLIENTCONFIG_V2 = 6,
+    PACKET_V2 = 7,
+    SCAN_START = 8,
+    SCAN_STOP = 9,
+    SCAN_AP_CNT = 10,
+    SCAN_AP_GET = 11,
+};
+
+struct __attribute__((packed)) Header {
+    MessageType type;
+    union {
+        uint8_t variable_byte; // generic name when setting the value from generic function
+        uint8_t version; // when type == DEVICE_INFO_V2
+        uint8_t up; // when type == PACKET_V2
+        uint8_t ap_count; // when type == SCAN_AP_CNT
+        uint8_t ap_index; // when type == SCAN_AP_GET
+    };
+    uint16_t size;
+};
+
+struct __attribute__((packed)) MessagePrelude {
+    Intron intron;
+    Header header;
+    uint32_t data_checksum;
+};
+
+namespace data {
+    struct APInfo {
+        APInfo() = default;
+        APInfo(APInfo &&) = default;
+        APInfo(const APInfo &) = delete;
+        APInfo &operator=(APInfo &&) = default;
+        APInfo &operator=(const APInfo &) = delete;
+
+        std::array<uint8_t, SSID_LEN> ssid;
+        bool requires_password;
+    };
+
+    using MacAddress = std::array<uint8_t, MAC_SIZE>;
+} // namespace data
+} // namespace esp

--- a/main/esp_protocol/parser.cpp
+++ b/main/esp_protocol/parser.cpp
@@ -25,7 +25,7 @@ void RxParserBase::reset() {
 
     msg = {};
     crc = 0;
-    buffer = std::span<uint8_t> {};
+    buffer = {};
     intron = esp::DEFAULT_INTRON;
     read = 0;
     state = State::Intron;

--- a/main/esp_protocol/parser.cpp
+++ b/main/esp_protocol/parser.cpp
@@ -1,0 +1,181 @@
+#include "parser.hpp"
+
+#include <iterator>
+#include <algorithm>
+#include <common/crc32.h>
+
+#if __has_include("lwip/def.h")
+    #include "lwip/def.h"
+#elif __has_include("arpa/inet.h")
+    #include "arpa/inet.h"
+#else
+    #error "Uart parser requires some type of ntohl/ntohs function. Feel free to add some extra header if needed"
+#endif
+
+namespace esp {
+
+void RxParserBase::set_intron(std::span<const uint8_t, INTRON_SIZE> new_intron) {
+    intron = new_intron;
+}
+
+void RxParserBase::reset() {
+    if (msg.header.type == esp::MessageType::PACKET_V2) {
+        reset_packet();
+    }
+
+    msg = {};
+    crc = 0;
+    buffer = std::span<uint8_t> {};
+    intron = esp::DEFAULT_INTRON;
+    read = 0;
+    state = State::Intron;
+    checksum_valid = true;
+}
+
+void RxParserBase::process_data(std::span<const uint8_t> input) {
+    curr = input.begin();
+    end = input.end();
+
+    while (curr != end) {
+        if (state == State::Intron) {
+            if (wait_for_intron()) {
+                crc = crc32_calc(intron.data(), intron.size());
+                state = State::Header;
+                buffer = std::span { reinterpret_cast<uint8_t *>(&msg.header), sizeof(msg) - sizeof(Intron) };
+                read = 0;
+            } else {
+                return;
+            }
+        }
+        if (state == State::Header) {
+            if (wait_for_buffer()) {
+                crc = crc32_calc_ex(crc, reinterpret_cast<uint8_t *>(&msg.header), sizeof(msg.header));
+                msg.header.size = ntohs(msg.header.size);
+                msg.data_checksum = ntohl(msg.data_checksum);
+
+                if (!validate_length_with_type()) {
+                    process_invalid_message();
+                    reset();
+                    continue;
+                }
+
+                // For packets this could be bigger then SMALL_BUFFER_SIZE, but the packets are handled by own buffer
+                buffer = std::span { small_buffer.data(), msg.header.size };
+                read = 0;
+                if (msg.header.type == esp::MessageType::PACKET_V2 && !start_packet()) {
+                    state = State::ThrowAwayData;
+                } else {
+                    state = State::Data;
+                }
+            } else {
+                return;
+            }
+        }
+        if (wait_for_data()) {
+            on_parsed();
+            reset();
+        } else {
+            return;
+        }
+    }
+}
+
+bool RxParserBase::wait_for_intron() {
+    while (curr != end) {
+        if (read == INTRON_SIZE) {
+            std::shift_left(msg.intron.begin(), msg.intron.end(), 1);
+            --read;
+        }
+
+        msg.intron.at(read) = *curr++;
+        ++read;
+
+        if (read == INTRON_SIZE) {
+            if (std::ranges::equal(msg.intron, intron)) {
+                return true;
+            }
+            // TODO: check for default intron to detect esp reset
+        }
+    }
+    return false; // No intron found yet!!
+}
+
+bool RxParserBase::wait_for_buffer() {
+    const auto remaining_data = std::distance(curr, end);
+    const auto to_read = buffer.size() - read;
+    const auto to_process = std::min<size_t>(remaining_data, to_read);
+
+    // Don't update the checksum calculation here!!!
+    // We are also loading the checksum itself so we don't want to include it in the calculation
+    std::copy(curr, std::next(curr, to_process), std::next(buffer.begin(), read));
+    std::advance(curr, to_process);
+    read += to_process;
+
+    return buffer.size() == read;
+}
+
+bool RxParserBase::wait_for_data() {
+    if (msg.header.size == 0) {
+        return true;
+    }
+
+    const auto remaining_data = std::distance(curr, end);
+    const auto to_read = buffer.size() - read;
+    const auto to_process = std::min<size_t>(remaining_data, to_read);
+    if (state == State::Data) {
+        const auto to_be_processed_data = std::span { &*curr, to_process };
+
+        crc = crc32_calc_ex(crc, to_be_processed_data.data(), to_be_processed_data.size());
+        switch (msg.header.type) {
+        case MessageType::PACKET_V2:
+            update_packet(to_be_processed_data);
+            break;
+        default:
+            std::copy(to_be_processed_data.begin(), to_be_processed_data.end(), std::next(buffer.begin(), read));
+            break;
+        }
+    }
+    std::advance(curr, to_process);
+    read += to_process;
+
+    return buffer.size() == read;
+}
+
+bool RxParserBase::validate_length_with_type() const {
+    switch (msg.header.type) {
+    case MessageType::SCAN_AP_CNT:
+        return msg.header.size == 0;
+    case MessageType::PACKET_V2:
+        return true;
+    case MessageType::DEVICE_INFO_V2:
+        return msg.header.size == sizeof(data::MacAddress);
+    case MessageType::SCAN_AP_GET:
+        return msg.header.size == sizeof(data::APInfo);
+    default:
+        return false;
+    }
+}
+
+void RxParserBase::on_parsed() {
+    checksum_valid = (crc == msg.data_checksum);
+    switch (msg.header.type) {
+    case MessageType::SCAN_AP_GET:
+        process_scan_ap_info();
+        break;
+    case MessageType::SCAN_AP_CNT:
+        process_scan_ap_count();
+        break;
+    case MessageType::DEVICE_INFO_V2:
+        process_esp_device_info();
+        break;
+    case MessageType::PACKET_V2:
+        if (state == State::Data) {
+            process_packet();
+        }
+        break;
+    default:
+        std::abort();
+    }
+}
+
+} // namespace esp

--- a/main/esp_protocol/parser.hpp
+++ b/main/esp_protocol/parser.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <span>
+
+#include "messages.hpp"
+
+namespace esp {
+
+struct RxParserBase {
+    RxParserBase() = default;
+    using Input = std::span<const uint8_t>;
+    static constexpr size_t SMALL_BUFFER_SIZE = 64;
+
+    void set_intron(std::span<const uint8_t, INTRON_SIZE> new_intron);
+
+    void process_data(Input data);
+
+    void reset();
+
+protected:
+    enum class State : uint8_t {
+        Intron,
+        Header,
+        Data,
+        ThrowAwayData,
+    };
+
+    [[nodiscard]] bool wait_for_intron();
+    [[nodiscard]] bool wait_for_buffer();
+    [[nodiscard]] bool wait_for_data();
+    [[nodiscard]] bool validate_length_with_type() const;
+    void on_parsed();
+
+    virtual void process_scan_ap_count() = 0;
+    virtual void process_scan_ap_info() = 0;
+    virtual void process_invalid_message() = 0;
+    virtual void process_esp_device_info() = 0;
+    virtual bool start_packet() = 0;
+    virtual void reset_packet() = 0;
+    virtual void update_packet(std::span<const uint8_t>) = 0;
+    virtual void process_packet() = 0;
+
+    MessagePrelude msg;
+    Input::iterator curr, end;
+    std::span<uint8_t> buffer;
+    uint32_t crc;
+
+private:
+    std::array<std::uint8_t, SMALL_BUFFER_SIZE> small_buffer;
+    std::span<const uint8_t> intron;
+    uint16_t read;
+    State state;
+
+protected:
+    bool checksum_valid;
+};
+
+} // namespace esp

--- a/main/esp_protocol/parser.hpp
+++ b/main/esp_protocol/parser.hpp
@@ -1,15 +1,14 @@
 #pragma once
 
+#include "messages.hpp"
+
 #include <array>
 #include <cstdint>
 #include <span>
 
-#include "messages.hpp"
-
 namespace esp {
 
 struct RxParserBase {
-    RxParserBase() = default;
     using Input = std::span<const uint8_t>;
     static constexpr size_t SMALL_BUFFER_SIZE = 64;
 

--- a/main/uart_nic.cpp
+++ b/main/uart_nic.cpp
@@ -448,7 +448,7 @@ static void send_device_info() {
     // MAC address
     int ret = esp_wifi_get_mac(WIFI_IF_STA, mac.data());
     if(ret != ESP_OK) {
-        ESP_LOGI(TAG, "Failed to obtain MAC, returning last one or zeroes");
+        ESP_LOGW(TAG, "Failed to obtain MAC, returning last one or zeroes");
     }
 
     uint32_t crc = 0;
@@ -622,7 +622,7 @@ static void IRAM_ATTR store_scanned_ssids(wifi_ap_record_t *aps, int ap_count) {
             break;
         }
         for (uint8_t j = 0; j < scan.stored_ssids_count; ++j) {
-            ESP_LOGI(TAG, "Comparing >%.32s< and %s", (char *)scan.stored_ssids[j].ssid.data(), (char *)aps[i].ssid);
+            ESP_LOGD(TAG, "Comparing >%.32s< and %s", (char *)scan.stored_ssids[j].ssid.data(), (char *)aps[i].ssid);
             if (memcmp(scan.stored_ssids[j].ssid.data(), aps[i].ssid, esp::SSID_LEN) == 0) {
                 found = true;
                 break;
@@ -775,9 +775,9 @@ static void IRAM_ATTR wifi_egress_thread(void *arg) {
                 continue;
             }
 
-            int8_t err = esp_wifi_internal_tx(WIFI_IF_STA, buff->data, buff->len);
+            const auto err = esp_wifi_internal_tx(WIFI_IF_STA, buff->data, buff->len);
             if (err != ESP_OK) {
-                ESP_LOGE(TAG, "Failed to send packet !!!");
+                ESP_LOGE(TAG, "Failed to send packet: %s!!!", esp_err_to_name(err));
             }
             free_wifi_send_buff(buff);
         }
@@ -828,7 +828,8 @@ static void IRAM_ATTR uart_tx_thread(void *arg) {
 extern "C" void app_main() {
     ESP_LOGI(TAG, "UART NIC");
 
-	// esp_log_level_set("*", ESP_LOG_ERROR);
+    esp_log_level_set("*", ESP_LOG_ERROR);
+    esp_log_level_set(TAG, ESP_LOG_WARN);
 
     ESP_ERROR_CHECK(nvs_flash_init());
 

--- a/main/uart_nic.cpp
+++ b/main/uart_nic.cpp
@@ -22,9 +22,8 @@
 
 #define UART_FULL_THRESH_DEFAULT (60)
 
-#include <string.h>
-#include <stdatomic.h>
-#include <stdbool.h>
+#include <cstring>
+#include <atomic>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/event_groups.h"
@@ -34,6 +33,7 @@
 #include "esp_netif.h"
 #include "esp_event.h"
 #include "esp_wifi.h"
+#include "esp_wifi_types.h"
 #include "nvs.h"
 #include "nvs_flash.h"
 
@@ -45,9 +45,10 @@
 #include "esp_wpa.h"
 #include <arpa/inet.h>
 
-
+extern "C" {
 // Externals with no header
 esp_err_t mac_init(void);
+}
 
 #define FW_VERSION 12
 
@@ -60,13 +61,13 @@ esp_err_t mac_init(void);
 // inactivity to a ridiculously long time and handle the disconnect ourselves.
 //
 // It's not longer for the only reason the uint16_t doesn't hold as big numbers.
-static const uint16_t INACTIVE_BEACON_SECONDS = 3600 * 18;
+static constexpr uint16_t INACTIVE_BEACON_SECONDS = 3600 * 18;
 // This is the effective timeout. If we don't receive any packet for this long,
 // we consider the signal lost.
 //
 // TODO: Shall we generate something to provoke getting some packets? Like ARP
 // pings to the AP?
-static const uint32_t INACTIVE_PACKET_SECONDS = 5;
+static constexpr uint32_t INACTIVE_PACKET_SECONDS = 5;
 
 #define MSG_DEVINFO_V2 0
 #define MSG_CLIENTCONFIG_V2 6
@@ -88,7 +89,7 @@ struct __attribute__((packed)) header {
     uint16_t size;
 };
 
-static const uint8_t uart_nic_protocol = WIFI_PROTOCOL_11B | WIFI_PROTOCOL_11G | WIFI_PROTOCOL_11N;
+static constexpr uint8_t uart_nic_protocol = WIFI_PROTOCOL_11B | WIFI_PROTOCOL_11G | WIFI_PROTOCOL_11N;
 
 static const char *TAG = "uart_nic";
 
@@ -105,14 +106,14 @@ static uint32_t now_seconds() {
     return xTaskGetTickCount() / configTICK_RATE_HZ;
 }
 
-static atomic_uint_least32_t last_inbound_seen = 0;
-static atomic_bool associated = false;
-static atomic_bool wifi_running = false;
-static atomic_bool connecting = false;
+static std::atomic<uint32_t> last_inbound_seen { 0 };
+static std::atomic<bool> associated = false;
+static std::atomic<bool> wifi_running = false;
+static std::atomic<bool> connecting = false;
 
 static bool beacon_quirk;
 static uint8_t probe_max_reties = 3;
-static atomic_bool probe_in_progress = false;
+static std::atomic<bool> probe_in_progress = false;
 static uint8_t probe_retry_count;
 static uint8_t latest_ssid[SSID_LEN];
 static uint8_t latest_bssid[BSSID_LEN];
@@ -133,22 +134,14 @@ const ScanResult EMPTY_RESULT = {};
 typedef void (*wifi_scan_callback)(wifi_ap_record_t *, int);
 
 static struct {
-    ScanType scan_type;
-    wifi_scan_callback callback;
-    uint32_t incremental_scan_time;
-    ScanResult stored_ssids[SCAN_MAX_STORED_SSIDS];
-    uint8_t stored_ssids_count;
-    atomic_bool in_progress;
-    atomic_bool should_reconnect;
-} scan = {
-    .scan_type = SCAN_TYPE_UNKNOWN,
-    .callback = NULL,
-    .incremental_scan_time = 0,
-    .stored_ssids = {},
-    .stored_ssids_count = 0,
-    .in_progress = false,
-    .should_reconnect = false,
-};
+    ScanType scan_type = SCAN_TYPE_UNKNOWN;
+    wifi_scan_callback callback = nullptr;
+    uint32_t incremental_scan_time = 0;
+    ScanResult stored_ssids[SCAN_MAX_STORED_SSIDS] {};
+    uint8_t stored_ssids_count = 0;
+    std::atomic<bool> in_progress = false;
+    std::atomic<bool> should_reconnect = false;
+} scan { };
 
 typedef struct {
     size_t len;
@@ -183,8 +176,8 @@ static void send_link_status(uint8_t up) {
     xSemaphoreGive(uart_mtx);
 }
 
-static void do_wifi_scan() {
-    wifi_scan_config_t config = {0};
+static void do_wifi_scan(void *) {
+    wifi_scan_config_t config{};
 
     config.scan_type = WIFI_SCAN_TYPE_ACTIVE;
     switch (scan.scan_type) {
@@ -360,9 +353,9 @@ static void IRAM_ATTR handle_disconnect_and_try_reconnect() {
 static void event_handler(void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data) {
     if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
         uint8_t current_protocol;
-        ESP_ERROR_CHECK(esp_wifi_get_protocol(ESP_IF_WIFI_STA, &current_protocol));
+        ESP_ERROR_CHECK(esp_wifi_get_protocol(WIFI_IF_STA, &current_protocol));
         if (current_protocol != uart_nic_protocol) {
-            ESP_ERROR_CHECK(esp_wifi_set_protocol(ESP_IF_WIFI_STA, uart_nic_protocol));
+            ESP_ERROR_CHECK(esp_wifi_set_protocol(WIFI_IF_STA, uart_nic_protocol));
             return;
         }
         start_wifi_connect_task();
@@ -383,7 +376,7 @@ static void event_handler(void* arg, esp_event_base_t event_base, int32_t event_
         beacon_quirk = true;
         send_link_status(1);
         s_retry_num = 0;
-        ESP_ERROR_CHECK(esp_wifi_set_inactive_time(ESP_IF_WIFI_STA, INACTIVE_BEACON_SECONDS));
+        ESP_ERROR_CHECK(esp_wifi_set_inactive_time(WIFI_IF_STA, INACTIVE_BEACON_SECONDS));
         cache_current_ap_info();
     } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_SCAN_DONE) {
         scan.in_progress = false;
@@ -421,38 +414,41 @@ static void event_handler(void* arg, esp_event_base_t event_base, int32_t event_
     }
 }
 
-static int IRAM_ATTR wifi_receive_cb(void *buffer, uint16_t len, void *eb) {
+static esp_err_t IRAM_ATTR wifi_receive_cb(void *buffer, uint16_t len, void *eb) {
     // ESP_LOGI(TAG, "Received wifi packet");
 
     // Seeing some traffic - we have signal :-)
     last_inbound_seen = now_seconds();
+
+    const auto cleanup = [&]() {
+        ESP_LOGW(TAG, "Failed to enqueue received wifi packet");
+        free(buffer);
+        esp_wifi_internal_free_rx_buffer(eb);
+    };
 
     // MAC filter
     if ((((const char*)buffer)[5] & 0x01) == 0) {
         for (uint i = 0; i < 6; ++i) {
             if(((const char*)buffer)[i] != mac[i]) {
                 ESP_LOGI(TAG, "Dropping packet based on mac filter");
-                goto cleanup;
+                cleanup();
+                return ESP_FAIL;
             }
         }
     }
 
-    wifi_receive_buff *buff = malloc(sizeof(wifi_receive_buff));
+    wifi_receive_buff *buff = static_cast<wifi_receive_buff *>(malloc(sizeof(wifi_receive_buff)));
     if(!buff) {
-        goto cleanup;
+        cleanup();
+        return ESP_FAIL;
     }
     buff->len = len;
     buff->data = buffer;
     buff->rx_buff = eb;
-    if (!xQueueSendToBack(uart_tx_queue, (void *)&buff, (TickType_t)0/*portMAX_DELAY*/)) {
+    if (!xQueueSendToBack(uart_tx_queue, (void *)&buff, portMAX_DELAY)) {
         free_wifi_receive_buff(buff);
     }
-    return 0;
-
-cleanup:
-    ESP_LOGI(TAG, "Failed to enqueue received wifi packet");
-    esp_wifi_internal_free_rx_buffer(eb);
-    return 0;
+    return ESP_OK;
 }
 
 void wifi_init_sta(void) {
@@ -462,7 +458,7 @@ void wifi_init_sta(void) {
     ESP_ERROR_CHECK(esp_wifi_init_internal(&cfg));
     ESP_ERROR_CHECK(esp_supplicant_init());
     ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, ESP_EVENT_ANY_ID, &event_handler, NULL));
-    ESP_ERROR_CHECK(esp_wifi_internal_reg_rxcb(ESP_IF_WIFI_STA, wifi_receive_cb));
+    ESP_ERROR_CHECK(esp_wifi_internal_reg_rxcb(WIFI_IF_STA, wifi_receive_cb));
     ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
 }
 
@@ -532,7 +528,7 @@ static void IRAM_ATTR read_packet_message(uint16_t size) {
     // ESP_LOGI(TAG, "Receiving packet size: %d", size);
     // ESP_LOGI(TAG, "Allocating pbuf size: %d, free heap: %d", size, esp_get_free_heap_size());
 
-    wifi_send_buff *buff = malloc(sizeof(wifi_send_buff));
+    wifi_send_buff *buff = static_cast<wifi_send_buff *>(malloc(sizeof(wifi_send_buff)));
     if(!buff) {
         goto nomem;
     }
@@ -543,7 +539,7 @@ static void IRAM_ATTR read_packet_message(uint16_t size) {
         goto nomem;
     }
 
-    read_uart(buff->data, buff->len);
+    read_uart(reinterpret_cast<uint8_t *>(buff->data), buff->len);
 
     if (!xQueueSendToBack(wifi_egress_queue, (void *)&buff, (TickType_t)0/*portMAX_DELAY*/)) {
         ESP_LOGI(TAG, "Out of space in egress queue");
@@ -602,7 +598,7 @@ static void read_wifi_client_message() {
 
     wifi_running = false;
     esp_wifi_stop();
-    ESP_ERROR_CHECK(esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_config) );
+    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config) );
     ESP_ERROR_CHECK(esp_wifi_start());
     wifi_running = true;
     send_device_info();
@@ -664,7 +660,7 @@ static void IRAM_ATTR store_scanned_ssids(wifi_ap_record_t *aps, int ap_count) {
         }
     }
 
-    struct header header = {0};
+    struct header header{};
     header.type = MSG_SCAN_AP_CNT;
     header.ap_count = scan.stored_ssids_count;
     xSemaphoreTake(uart_mtx, portMAX_DELAY);
@@ -676,7 +672,7 @@ static void IRAM_ATTR store_scanned_ssids(wifi_ap_record_t *aps, int ap_count) {
 }
 
 static void IRAM_ATTR send_scanned_ssid(uint8_t index, const ScanResult* scan) {
-    struct header header = {0};
+    struct header header{};
     header.type = MSG_SCAN_AP_GET;
     header.ap_index = index;
     header.size = htons(sizeof(ScanResult));
@@ -772,7 +768,7 @@ static void IRAM_ATTR wifi_egress_thread(void *arg) {
                 continue;
             }
 
-            int8_t err = esp_wifi_internal_tx(ESP_IF_WIFI_STA, buff->data, buff->len);
+            int8_t err = esp_wifi_internal_tx(WIFI_IF_STA, buff->data, buff->len);
             if (err != ESP_OK) {
                 ESP_LOGI(TAG, "Failed to send packet !!!");
             }
@@ -815,7 +811,7 @@ static void IRAM_ATTR uart_tx_thread(void *arg) {
     }
 }
 
-void app_main() {
+extern "C" void app_main() {
     ESP_LOGI(TAG, "UART NIC");
 
 	// esp_log_level_set("*", ESP_LOG_ERROR);
@@ -831,7 +827,9 @@ void app_main() {
         .data_bits = UART_DATA_8_BITS,
         .parity    = UART_PARITY_DISABLE,
         .stop_bits = UART_STOP_BITS_1,
-        .flow_ctrl = UART_HW_FLOWCTRL_DISABLE
+        .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
+        .rx_flow_ctrl_thresh = 0,
+        .source_clk = UART_SCLK_DEFAULT,
     };
     uart_driver_install(UART_NUM_0, 16384, 0, 0, NULL, 0);
     uart_param_config(UART_NUM_0, &uart_config);
@@ -840,9 +838,9 @@ void app_main() {
         | UART_RXFIFO_TOUT_INT_ENA_M
         | UART_FRM_ERR_INT_ENA_M
         | UART_RXFIFO_OVF_INT_ENA_M,
-        .rxfifo_full_thresh = 80,
         .rx_timeout_thresh = 1,
-        .txfifo_empty_intr_thresh = 40
+        .txfifo_empty_intr_thresh = 40,
+        .rxfifo_full_thresh = 80,
     };
     uart_intr_config(UART_NUM_0, &uart_intr);
 

--- a/main/uart_nic.cpp
+++ b/main/uart_nic.cpp
@@ -427,7 +427,9 @@ static esp_err_t IRAM_ATTR wifi_receive_cb(void *buffer, uint16_t len, void *eb)
     buff->data = buffer;
     buff->rx_buff = eb;
     if (!xQueueSendToBack(uart_tx_queue, (void *)&buff, portMAX_DELAY)) {
+        cleanup();
         free_wifi_receive_buff(buff);
+        return ESP_FAIL;
     }
     return ESP_OK;
 }

--- a/main/uart_nic.cpp
+++ b/main/uart_nic.cpp
@@ -25,12 +25,15 @@
 #include <cstring>
 #include <cstdint>
 #include <atomic>
+#include <algorithm>
+#include <span>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/event_groups.h"
 #include "freertos/queue.h"
 #include "esp_system.h"
 #include "esp_log.h"
+#include "esp_crc.h"
 #include "esp_netif.h"
 #include "esp_event.h"
 #include "esp_wifi.h"
@@ -125,7 +128,7 @@ typedef struct {
 
 typedef struct {
     size_t len;
-    void *data;
+    uint8_t *data;
 } wifi_send_buff;
 
 static void IRAM_ATTR free_wifi_receive_buff(wifi_receive_buff *buff) {
@@ -134,17 +137,20 @@ static void IRAM_ATTR free_wifi_receive_buff(wifi_receive_buff *buff) {
 }
 
 static void IRAM_ATTR free_wifi_send_buff(wifi_send_buff *buff) {
-    if(buff->data) free(buff->data);
+    if (buff->data) delete [] buff->data;
     free(buff);
 }
 
 static void send_link_status(uint8_t up) {
     ESP_LOGI(TAG, "Sending link status: %d", up);
+    uint32_t crc = 0;
+    crc = esp_crc32_le(crc, intron.data(), intron.size());
     esp::MessagePrelude message{};
     message.header.type = esp::MessageType::PACKET_V2;
     message.header.up = up;
     message.header.size = htons(0);
-    message.data_checksum = htonl(0);
+    crc = esp_crc32_le(crc, reinterpret_cast<uint8_t *>(&message.header), sizeof(message.header));
+    message.data_checksum = htonl(crc);
     xSemaphoreTake(uart_mtx, portMAX_DELAY);
     uart_write_bytes(UART_NUM_0, intron.data(), intron.size());
     uart_write_bytes(UART_NUM_0, (const char*)&message.header, sizeof(message.header) + sizeof(message.data_checksum));
@@ -445,11 +451,15 @@ static void send_device_info() {
         ESP_LOGI(TAG, "Failed to obtain MAC, returning last one or zeroes");
     }
 
+    uint32_t crc = 0;
+    crc = esp_crc32_le(crc, intron.data(), intron.size());
     esp::MessagePrelude message;
     message.header.type = esp::MessageType::DEVICE_INFO_V2;
     message.header.version = esp::REQUIRED_PROTOCOL_VERSION;
     message.header.size = htons(mac.size());
-    message.data_checksum = htonl(0);
+    crc = esp_crc32_le(crc, reinterpret_cast<uint8_t *>(&message.header), sizeof(message.header));
+    crc = esp_crc32_le(crc, mac.data(), mac.size());
+    message.data_checksum = htonl(crc);
     xSemaphoreTake(uart_mtx, portMAX_DELAY);
     uart_write_bytes(UART_NUM_0, intron.data(), intron.size());
     uart_write_bytes(UART_NUM_0, (const char*)&message.header, sizeof(message.header) + sizeof(message.data_checksum));
@@ -500,61 +510,52 @@ static size_t IRAM_ATTR read_uart(uint8_t *buff, size_t len) {
     return trr;
 }
 
-static void IRAM_ATTR read_packet_message(uint16_t size) {
-    // ESP_LOGI(TAG, "Receiving packet size: %d", size);
-    // ESP_LOGI(TAG, "Allocating pbuf size: %d, free heap: %d", size, esp_get_free_heap_size());
-
+static void IRAM_ATTR read_packet_message(uint8_t *data, uint16_t size) {
     wifi_send_buff *buff = static_cast<wifi_send_buff *>(malloc(sizeof(wifi_send_buff)));
     if(!buff) {
-        goto nomem;
+        delete [] data;
+        ESP_LOGE(TAG, "Out of mem for packet data");
+        return;
     }
     buff->len = size;
-    buff->data = malloc(buff->len);
-    if(!buff->data) {
-        free(buff);
-        goto nomem;
-    }
+    buff->data = data;
 
-    read_uart(reinterpret_cast<uint8_t *>(buff->data), buff->len);
-
-    if (!xQueueSendToBack(wifi_egress_queue, (void *)&buff, (TickType_t)0/*portMAX_DELAY*/)) {
-        ESP_LOGI(TAG, "Out of space in egress queue");
+    if (!xQueueSendToBack(wifi_egress_queue, (void *)&buff, portMAX_DELAY)) {
+        ESP_LOGE(TAG, "Out of space in egress queue");
         free_wifi_send_buff(buff);
-    }
-    return;
-
-nomem:
-    ESP_LOGI(TAG, "Out of mem for packet data");
-    for(uint i = 0; i < size; ++i) {
-        uint8_t c;
-        read_uart(&c, 1);
     }
     return;
 }
 
-static void read_wifi_client_message() {
-    read_uart(intron.data(), intron.size());
+static void read_wifi_client_message(std::span<const uint8_t> data) {
+    auto current = data.begin();
+    std::copy_n(data.begin(), intron.size(), intron.begin());
+    std::advance(current, intron.size());
 
     wifi_config_t wifi_config;
     memset(&wifi_config, 0, sizeof(wifi_config_t));
 
-    uint8_t ssid_len = 0;
-    read_uart(&ssid_len, 1);
+    uint8_t ssid_len = *current++;
     ESP_LOGI(TAG, "Reading SSID len: %d", ssid_len);
     if(ssid_len > sizeof(wifi_config.sta.ssid)) {
         ESP_LOGI(TAG, "SSID too long, trimming");
         ssid_len = sizeof(wifi_config.sta.ssid);
     }
-    read_uart(wifi_config.sta.ssid, ssid_len);
+    std::copy_n(current, ssid_len, wifi_config.sta.ssid);
+    std::advance(current, ssid_len);
 
-    uint8_t pass_len = 0;
-    read_uart(&pass_len, 1);
+    uint8_t pass_len = *current++;
     ESP_LOGI(TAG, "Reading PASS len: %d", pass_len);
     if(pass_len > sizeof(wifi_config.sta.password)) {
         ESP_LOGI(TAG, "PASS too long, trimming");
         pass_len = sizeof(wifi_config.sta.password);
     }
-    read_uart(wifi_config.sta.password, pass_len);
+    std::copy_n(current, pass_len, wifi_config.sta.password);
+    std::advance(current, pass_len);
+
+    if (current != data.end()) {
+        ESP_LOGE(TAG, "Client config: Not all data processed");
+    }
 
     ESP_LOGI(TAG, "Reconfiguring wifi");
 
@@ -636,10 +637,13 @@ static void IRAM_ATTR store_scanned_ssids(wifi_ap_record_t *aps, int ap_count) {
     }
 
     esp::MessagePrelude message{};
+    uint32_t crc = 0;
+    crc = esp_crc32_le(crc, intron.data(), intron.size());
     message.header.type = esp::MessageType::SCAN_AP_CNT;
     message.header.ap_index = scan.stored_ssids_count;
     message.header.size = 0;
-    message.data_checksum = htonl(0);
+    crc = esp_crc32_le(crc, reinterpret_cast<uint8_t*>(&message.header), sizeof(message.header));
+    message.data_checksum = htonl(crc);
     xSemaphoreTake(uart_mtx, portMAX_DELAY);
     uart_write_bytes(UART_NUM_0, intron.data(), intron.size());
     uart_write_bytes(UART_NUM_0, (const char*)&message.header, sizeof(message.header) + sizeof(message.data_checksum));
@@ -650,10 +654,14 @@ static void IRAM_ATTR store_scanned_ssids(wifi_ap_record_t *aps, int ap_count) {
 
 static void IRAM_ATTR send_scanned_ssid(uint8_t index, const esp::data::APInfo& scan_ap_info) {
     esp::MessagePrelude message;
+    uint32_t crc = 0;
+    crc = esp_crc32_le(crc, intron.data(), intron.size());
     message.header.type = esp::MessageType::SCAN_AP_GET;
     message.header.ap_index = index;
     message.header.size = htons(sizeof(esp::data::APInfo));
-    message.data_checksum = htonl(0);
+    crc = esp_crc32_le(crc, reinterpret_cast<uint8_t *>(&message.header), sizeof(message.header));
+    crc = esp_crc32_le(crc, reinterpret_cast<const uint8_t *>(&scan_ap_info), sizeof(scan_ap_info));
+    message.data_checksum = htonl(crc);
     xSemaphoreTake(uart_mtx, portMAX_DELAY);
     uart_write_bytes(UART_NUM_0, intron.data(), intron.size());
     uart_write_bytes(UART_NUM_0, (const char*)&message.header, sizeof(message.header) + sizeof(message.data_checksum));
@@ -693,39 +701,59 @@ static void IRAM_ATTR read_message() {
         return;
     }
 
+    uint32_t crc = 0;
+    crc = esp_crc32_le(crc, intron.data(), intron.size());
+    crc = esp_crc32_le(crc, reinterpret_cast<uint8_t *>(&message.header), sizeof(message.header));
     message.header.size = ntohs(message.header.size);
     message.data_checksum = ntohl(message.data_checksum);
 
-    switch (message.header.type) {
-        case esp::MessageType::PACKET_V2: {
-            if (message.header.size > 0) {
-                read_packet_message(message.header.size);
-            } else {
-                send_link_status(get_link_status());
+    uint8_t* data = nullptr;
+    if (message.header.size > 0) {
+        data = new uint8_t[message.header.size];
+        read_uart(data, message.header.size);
+        crc = esp_crc32_le(crc, data, message.header.size);
+    }
+
+    if (message.data_checksum == crc) {
+        switch (message.header.type) {
+            case esp::MessageType::PACKET_V2: {
+                if (message.header.size > 0) {
+                    read_packet_message(data, message.header.size);
+                    data = nullptr;
+                } else {
+                    send_link_status(get_link_status());
+                }
             }
             break;
-        case esp::MessageType::CLIENTCONFIG_V2:
-            read_wifi_client_message();
+            case esp::MessageType::CLIENTCONFIG_V2:
+                read_wifi_client_message(std::span{data, message.header.size});
             break;
-        case esp::MessageType::SCAN_START:
-            handle_rx_msg_scan_start();
+            case esp::MessageType::SCAN_START:
+                handle_rx_msg_scan_start();
             break;
-        case esp::MessageType::SCAN_STOP:
-            handle_rx_msg_scan_stop();
+            case esp::MessageType::SCAN_STOP:
+                handle_rx_msg_scan_stop();
             break;
-        case esp::MessageType::SCAN_AP_CNT:
-            ESP_LOGE(TAG, "esp::MessageType::SCAN_AP_CNT is only transmitted, never recieved");
+            case esp::MessageType::SCAN_AP_CNT:
+                ESP_LOGE(TAG, "esp::MessageType::SCAN_AP_CNT is only transmitted, never recieved");
             break;
-        case esp::MessageType::SCAN_AP_GET:
-            handle_rx_msg_scan_get(message.header);
+            case esp::MessageType::SCAN_AP_GET:
+                handle_rx_msg_scan_get(message.header);
             break;
-        case esp::MessageType::DEVICE_INFO_V2:
-            ESP_LOGE(TAG, "esp::MessageType::DEVICE_INFO_V2 is only transmitted, never recieved");
+            case esp::MessageType::DEVICE_INFO_V2:
+                ESP_LOGE(TAG, "esp::MessageType::DEVICE_INFO_V2 is only transmitted, never recieved");
             break;
-        default:
-            ESP_LOGE(TAG, "Unknown message type: %d !!!", static_cast<uint8_t>(message.header.type));
+            default:
+                ESP_LOGE(TAG, "Unknown message type: %d !!!", static_cast<uint8_t>(message.header.type));
             break;
         }
+    } else {
+        ESP_LOGE(TAG, "Checksum mismatch. MT: %d, ref: %lx calc: %lx",
+                      static_cast<int>(message.header.type), message.data_checksum, crc);
+    }
+
+    if (data != nullptr) {
+        delete[] data;
     }
 
     // Check that we are receiving some packets from the AP. We do so in the
@@ -743,13 +771,13 @@ static void IRAM_ATTR wifi_egress_thread(void *arg) {
         wifi_send_buff *buff;
         if(xQueueReceive(wifi_egress_queue, &buff, (TickType_t)portMAX_DELAY)) {
             if (!buff) {
-                ESP_LOGI(TAG, "NULL pulled from egress queue");
+                ESP_LOGW(TAG, "NULL pulled from egress queue");
                 continue;
             }
 
             int8_t err = esp_wifi_internal_tx(WIFI_IF_STA, buff->data, buff->len);
             if (err != ESP_OK) {
-                ESP_LOGI(TAG, "Failed to send packet !!!");
+                ESP_LOGE(TAG, "Failed to send packet !!!");
             }
             free_wifi_send_buff(buff);
         }
@@ -778,10 +806,14 @@ static void IRAM_ATTR uart_tx_thread(void *arg) {
                 continue;
             }
             esp::MessagePrelude message{};
+            uint32_t crc = 0;
+            crc = esp_crc32_le(crc, intron.data(), intron.size());
             message.header.type = esp::MessageType::PACKET_V2;
             message.header.up = get_link_status();
             message.header.size = htons(buff->len);
-            message.data_checksum = htonl(0);
+            crc = esp_crc32_le(crc, reinterpret_cast<uint8_t *>(&message.header), sizeof(message.header));
+            crc = esp_crc32_le(crc, reinterpret_cast<uint8_t *>(buff->data), buff->len);
+            message.data_checksum = htonl(crc);
             xSemaphoreTake(uart_mtx, portMAX_DELAY);
             uart_write_bytes(UART_NUM_0, intron.data(), intron.size());
             uart_write_bytes(UART_NUM_0, (const char*)&message.header, sizeof(message.header) + sizeof(message.data_checksum));

--- a/main/uart_nic.cpp
+++ b/main/uart_nic.cpp
@@ -601,7 +601,6 @@ static void read_wifi_client_message() {
     ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config) );
     ESP_ERROR_CHECK(esp_wifi_start());
     wifi_running = true;
-    send_device_info();
 }
 
 static int get_link_status() {
@@ -785,6 +784,9 @@ static void IRAM_ATTR output_rx_thread(void *arg) {
 }
 
 static void IRAM_ATTR uart_tx_thread(void *arg) {
+    // same as ESP8266 wait a second after start to make sure we are able to receive device info on printer startup
+    vTaskDelay(1000 / portTICK_PERIOD_MS);
+
     // Send initial device info to let master know ESP is ready
     send_device_info();
 

--- a/main/uart_nic.cpp
+++ b/main/uart_nic.cpp
@@ -23,6 +23,7 @@
 #define UART_FULL_THRESH_DEFAULT (60)
 
 #include <cstring>
+#include <cstdint>
 #include <atomic>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -50,11 +51,10 @@ extern "C" {
 esp_err_t mac_init(void);
 }
 
-#define FW_VERSION 12
+#include "esp_protocol/messages.hpp"
 
-#define SCAN_MAX_STORED_SSIDS 64
-#define SSID_LEN 32
-#define BSSID_LEN 6
+static constexpr size_t SCAN_MAX_STORED_SSIDS = 64;
+static constexpr size_t BSSID_LEN = 6;
 
 // Hack: because we don't see the beacon on some networks (and it's quite
 // common), but don't want to be "flapping", we set the timeout for beacon
@@ -69,38 +69,17 @@ static constexpr uint16_t INACTIVE_BEACON_SECONDS = 3600 * 18;
 // pings to the AP?
 static constexpr uint32_t INACTIVE_PACKET_SECONDS = 5;
 
-#define MSG_DEVINFO_V2 0
-#define MSG_CLIENTCONFIG_V2 6
-#define MSG_PACKET_V2 7
-#define MSG_SCAN_START 8
-#define MSG_SCAN_STOP 9
-#define MSG_SCAN_AP_CNT 10
-#define MSG_SCAN_AP_GET 11
-
-struct __attribute__((packed)) header {
-    uint8_t type;
-    union {
-        uint8_t version;  // when type == MSG_DEVINFO_V2
-        uint8_t unused;   // when type == MSG_CLIENTCONFIG_V2 || type == MSG_SCAN_START || type == MSG_SCAN_STOP
-        uint8_t up;       // when type == MSG_PACKET_V2
-        uint8_t ap_count; // when type == MSG_SCAN_AP_GET
-        uint8_t ap_index; // when type == MSG_SCAN_AP_GET
-    };
-    uint16_t size;
-};
-
 static constexpr uint8_t uart_nic_protocol = WIFI_PROTOCOL_11B | WIFI_PROTOCOL_11G | WIFI_PROTOCOL_11N;
 
 static const char *TAG = "uart_nic";
 
-SemaphoreHandle_t uart_mtx = NULL;
+SemaphoreHandle_t uart_mtx = nullptr;
 static int s_retry_num = 0;
-QueueHandle_t uart_tx_queue = 0;
-QueueHandle_t wifi_egress_queue = 0;
+QueueHandle_t uart_tx_queue = nullptr;
+QueueHandle_t wifi_egress_queue = nullptr;
 
-static char intron[8] = {'U', 'N', '\x00', '\x01', '\x02', '\x03', '\x04', '\x05'};
-#define MAC_LEN 6
-static uint8_t mac[MAC_LEN];
+static esp::Intron intron = esp::DEFAULT_INTRON;
+static esp::data::MacAddress mac;
 
 static uint32_t now_seconds() {
     return xTaskGetTickCount() / configTICK_RATE_HZ;
@@ -115,7 +94,7 @@ static bool beacon_quirk;
 static uint8_t probe_max_reties = 3;
 static std::atomic<bool> probe_in_progress = false;
 static uint8_t probe_retry_count;
-static uint8_t latest_ssid[SSID_LEN];
+static uint8_t latest_ssid[esp::SSID_LEN];
 static uint8_t latest_bssid[BSSID_LEN];
 
 typedef enum {
@@ -124,12 +103,7 @@ typedef enum {
     SCAN_TYPE_INCREMENTAL,
 } ScanType;
 
-typedef struct __attribute__((packed)) {
-    uint8_t ssid[SSID_LEN];
-    bool needs_password;
-} ScanResult;
-
-const ScanResult EMPTY_RESULT = {};
+static constexpr esp::data::APInfo EMPTY_RESULT = {};
 
 typedef void (*wifi_scan_callback)(wifi_ap_record_t *, int);
 
@@ -137,7 +111,7 @@ static struct {
     ScanType scan_type = SCAN_TYPE_UNKNOWN;
     wifi_scan_callback callback = nullptr;
     uint32_t incremental_scan_time = 0;
-    ScanResult stored_ssids[SCAN_MAX_STORED_SSIDS] {};
+    esp::data::APInfo stored_ssids[SCAN_MAX_STORED_SSIDS] {};
     uint8_t stored_ssids_count = 0;
     std::atomic<bool> in_progress = false;
     std::atomic<bool> should_reconnect = false;
@@ -166,13 +140,14 @@ static void IRAM_ATTR free_wifi_send_buff(wifi_send_buff *buff) {
 
 static void send_link_status(uint8_t up) {
     ESP_LOGI(TAG, "Sending link status: %d", up);
-    struct header header;
-    header.type = MSG_PACKET_V2;
-    header.up = up;
-    header.size = htons(0);
+    esp::MessagePrelude message{};
+    message.header.type = esp::MessageType::PACKET_V2;
+    message.header.up = up;
+    message.header.size = htons(0);
+    message.data_checksum = htonl(0);
     xSemaphoreTake(uart_mtx, portMAX_DELAY);
-    uart_write_bytes(UART_NUM_0, intron, sizeof(intron));
-    uart_write_bytes(UART_NUM_0, (const char*)&header, sizeof(header));
+    uart_write_bytes(UART_NUM_0, intron.data(), intron.size());
+    uart_write_bytes(UART_NUM_0, (const char*)&message.header, sizeof(message.header) + sizeof(message.data_checksum));
     xSemaphoreGive(uart_mtx);
 }
 
@@ -269,7 +244,7 @@ static void IRAM_ATTR cache_current_ap_info() {
     wifi_ap_record_t ap_info;
     if (esp_wifi_sta_get_ap_info(&ap_info) == ESP_OK) {
         memcpy(latest_bssid, ap_info.bssid, BSSID_LEN);
-        memcpy(latest_ssid, ap_info.ssid, SSID_LEN);
+        memcpy(latest_ssid, ap_info.ssid, esp::SSID_LEN);
     }
 }
 
@@ -295,7 +270,7 @@ static void IRAM_ATTR probe_handler(wifi_ap_record_t* aps, int ap_count) {
     if (beacon_quirk && !found) {
         for (int i = 0; i < ap_count; ++i) {
             if (latest_ssid[0] && aps[i].ssid[0]) {
-                if (0 == strncmp((char *)(latest_ssid), (char *)(aps[i].ssid), SSID_LEN)) {
+                if (0 == strncmp((char *)(latest_ssid), (char *)(aps[i].ssid), esp::SSID_LEN)) {
                     found = true;
                     break;
                 }
@@ -465,19 +440,20 @@ void wifi_init_sta(void) {
 static void send_device_info() {
     ESP_LOGI(TAG, "Sending device info");
     // MAC address
-    int ret = esp_wifi_get_mac(WIFI_IF_STA, mac);
+    int ret = esp_wifi_get_mac(WIFI_IF_STA, mac.data());
     if(ret != ESP_OK) {
         ESP_LOGI(TAG, "Failed to obtain MAC, returning last one or zeroes");
     }
 
-    struct header header;
-    header.type = MSG_DEVINFO_V2;
-    header.version = FW_VERSION;
-    header.size = htons(6);
+    esp::MessagePrelude message;
+    message.header.type = esp::MessageType::DEVICE_INFO_V2;
+    message.header.version = esp::REQUIRED_PROTOCOL_VERSION;
+    message.header.size = htons(mac.size());
+    message.data_checksum = htonl(0);
     xSemaphoreTake(uart_mtx, portMAX_DELAY);
-    uart_write_bytes(UART_NUM_0, intron, sizeof(intron));
-    uart_write_bytes(UART_NUM_0, (const char*)&header, sizeof(header));
-    uart_write_bytes(UART_NUM_0, (const char*)mac, sizeof(mac));
+    uart_write_bytes(UART_NUM_0, intron.data(), intron.size());
+    uart_write_bytes(UART_NUM_0, (const char*)&message.header, sizeof(message.header) + sizeof(message.data_checksum));
+    uart_write_bytes(UART_NUM_0, mac.data(), mac.size());
     xSemaphoreGive(uart_mtx);
 }
 
@@ -557,7 +533,7 @@ nomem:
 }
 
 static void read_wifi_client_message() {
-    read_uart((uint8_t*)intron, sizeof(intron));
+    read_uart(intron.data(), intron.size());
 
     wifi_config_t wifi_config;
     memset(&wifi_config, 0, sizeof(wifi_config_t));
@@ -645,40 +621,43 @@ static void IRAM_ATTR store_scanned_ssids(wifi_ap_record_t *aps, int ap_count) {
             break;
         }
         for (uint8_t j = 0; j < scan.stored_ssids_count; ++j) {
-            ESP_LOGI(TAG, "Comparing >%s< and %s", (char *)scan.stored_ssids[j].ssid, (char *)aps[i].ssid);
-            if (memcmp(scan.stored_ssids[j].ssid, aps[i].ssid, SSID_LEN) == 0) {
+            ESP_LOGI(TAG, "Comparing >%.32s< and %s", (char *)scan.stored_ssids[j].ssid.data(), (char *)aps[i].ssid);
+            if (memcmp(scan.stored_ssids[j].ssid.data(), aps[i].ssid, esp::SSID_LEN) == 0) {
                 found = true;
                 break;
             }
         }
         if (!found) {
-            memcpy(scan.stored_ssids[scan.stored_ssids_count].ssid, aps[i].ssid, SSID_LEN);
-            scan.stored_ssids[scan.stored_ssids_count].needs_password = aps[i].authmode != WIFI_AUTH_OPEN || aps[i].pairwise_cipher != WIFI_CIPHER_TYPE_NONE;
+            memcpy(scan.stored_ssids[scan.stored_ssids_count].ssid.data(), aps[i].ssid, esp::SSID_LEN);
+            scan.stored_ssids[scan.stored_ssids_count].requires_password = aps[i].authmode != WIFI_AUTH_OPEN || aps[i].pairwise_cipher != WIFI_CIPHER_TYPE_NONE;
             scan.stored_ssids_count ++;
             ESP_LOGI(TAG, "Found SSID: %s", aps[i].ssid);
         }
     }
 
-    struct header header{};
-    header.type = MSG_SCAN_AP_CNT;
-    header.ap_count = scan.stored_ssids_count;
+    esp::MessagePrelude message{};
+    message.header.type = esp::MessageType::SCAN_AP_CNT;
+    message.header.ap_index = scan.stored_ssids_count;
+    message.header.size = 0;
+    message.data_checksum = htonl(0);
     xSemaphoreTake(uart_mtx, portMAX_DELAY);
-    uart_write_bytes(UART_NUM_0, intron, sizeof(intron));
-    uart_write_bytes(UART_NUM_0, (const char*)&header, sizeof(header));
+    uart_write_bytes(UART_NUM_0, intron.data(), intron.size());
+    uart_write_bytes(UART_NUM_0, (const char*)&message.header, sizeof(message.header) + sizeof(message.data_checksum));
     xSemaphoreGive(uart_mtx);
 
     ESP_LOGI(TAG, "Scan done. Found: %d", scan.stored_ssids_count);
 }
 
-static void IRAM_ATTR send_scanned_ssid(uint8_t index, const ScanResult* scan) {
-    struct header header{};
-    header.type = MSG_SCAN_AP_GET;
-    header.ap_index = index;
-    header.size = htons(sizeof(ScanResult));
+static void IRAM_ATTR send_scanned_ssid(uint8_t index, const esp::data::APInfo& scan_ap_info) {
+    esp::MessagePrelude message;
+    message.header.type = esp::MessageType::SCAN_AP_GET;
+    message.header.ap_index = index;
+    message.header.size = htons(sizeof(esp::data::APInfo));
+    message.data_checksum = htonl(0);
     xSemaphoreTake(uart_mtx, portMAX_DELAY);
-    uart_write_bytes(UART_NUM_0, intron, sizeof(intron));
-    uart_write_bytes(UART_NUM_0, (const char*)&header, sizeof(header));
-    uart_write_bytes(UART_NUM_0, (const char*)scan, sizeof(ScanResult));
+    uart_write_bytes(UART_NUM_0, intron.data(), intron.size());
+    uart_write_bytes(UART_NUM_0, (const char*)&message.header, sizeof(message.header) + sizeof(message.data_checksum));
+    uart_write_bytes(UART_NUM_0, (const char*)&scan_ap_info, sizeof(scan_ap_info));
     xSemaphoreGive(uart_mtx);
 }
 
@@ -696,56 +675,57 @@ static void IRAM_ATTR handle_rx_msg_scan_stop() {
     force_stop_wifi_scan();
 }
 
-static void IRAM_ATTR handle_rx_msg_scan_get(struct header header) {
+static void IRAM_ATTR handle_rx_msg_scan_get(const esp::Header& header) {
     if (header.ap_index < scan.stored_ssids_count) {
-        send_scanned_ssid(header.ap_index, &scan.stored_ssids[header.ap_index]);
+        send_scanned_ssid(header.ap_index, scan.stored_ssids[header.ap_index]);
     } else {
-        send_scanned_ssid(UINT8_MAX, &EMPTY_RESULT);
+        send_scanned_ssid(UINT8_MAX, EMPTY_RESULT);
     }
 }
 
 static void IRAM_ATTR read_message() {
     wait_for_intron();
 
-    struct header header;
-    size_t read = uart_read_bytes(UART_NUM_0, (uint8_t*)&header, sizeof(header), portMAX_DELAY);
-    if (read != sizeof(header)) {
+    esp::MessagePrelude message;
+    size_t read = uart_read_bytes(UART_NUM_0, (uint8_t*)&message.header, sizeof(message.header) + sizeof(message.data_checksum), portMAX_DELAY);
+    if (read != sizeof(message.header) + sizeof(message.data_checksum)) {
         ESP_LOGI(TAG, "Cannot read message header");
         return;
     }
 
-    header.size = ntohs(header.size);
+    message.header.size = ntohs(message.header.size);
+    message.data_checksum = ntohl(message.data_checksum);
 
-    switch (header.type) {
-        case MSG_PACKET_V2: {
-            if (header.size > 0) {
-                read_packet_message(header.size);
+    switch (message.header.type) {
+        case esp::MessageType::PACKET_V2: {
+            if (message.header.size > 0) {
+                read_packet_message(message.header.size);
             } else {
                 send_link_status(get_link_status());
             }
-        }
-        break;
-        case MSG_CLIENTCONFIG_V2:
+            break;
+        case esp::MessageType::CLIENTCONFIG_V2:
             read_wifi_client_message();
-        break;
-        case MSG_SCAN_START:
+            break;
+        case esp::MessageType::SCAN_START:
             handle_rx_msg_scan_start();
-        break;
-        case MSG_SCAN_STOP:
+            break;
+        case esp::MessageType::SCAN_STOP:
             handle_rx_msg_scan_stop();
-        break;
-        case MSG_SCAN_AP_CNT:
-            ESP_LOGE(TAG, "MSG_SCAN_AP_CNT is only transmitted, never recieved");
-        break;
-        case MSG_SCAN_AP_GET:
-            handle_rx_msg_scan_get(header);
-        break;
-        case MSG_DEVINFO_V2:
-            ESP_LOGE(TAG, "MSG_DEVINFO_V2 is only transmitted, never recieved");
-        break;
+            break;
+        case esp::MessageType::SCAN_AP_CNT:
+            ESP_LOGE(TAG, "esp::MessageType::SCAN_AP_CNT is only transmitted, never recieved");
+            break;
+        case esp::MessageType::SCAN_AP_GET:
+            handle_rx_msg_scan_get(message.header);
+            break;
+        case esp::MessageType::DEVICE_INFO_V2:
+            ESP_LOGE(TAG, "esp::MessageType::DEVICE_INFO_V2 is only transmitted, never recieved");
+            break;
         default:
-            ESP_LOGE(TAG, "Unknown message type: %d !!!", header.type);
-        break;
+            ESP_LOGE(TAG, "Unknown message type: %d !!!", static_cast<uint8_t>(message.header.type));
+            break;
+        }
     }
 
     // Check that we are receiving some packets from the AP. We do so in the
@@ -794,17 +774,17 @@ static void IRAM_ATTR uart_tx_thread(void *arg) {
         wifi_receive_buff *buff;
         if(xQueueReceive(uart_tx_queue, &buff, (TickType_t)1000 /*portMAX_DELAY*/)) {
             if (!buff) {
-                ESP_LOGI(TAG, "Skipping packet with null buffer");
+                ESP_LOGW(TAG, "Skipping packet with null buffer");
                 continue;
             }
-            // ESP_LOGI(TAG, "Printing packet to UART");
-            struct header header;
-            header.type = MSG_PACKET_V2;
-            header.up = get_link_status();
-            header.size = htons(buff->len);
+            esp::MessagePrelude message{};
+            message.header.type = esp::MessageType::PACKET_V2;
+            message.header.up = get_link_status();
+            message.header.size = htons(buff->len);
+            message.data_checksum = htonl(0);
             xSemaphoreTake(uart_mtx, portMAX_DELAY);
-            uart_write_bytes(UART_NUM_0, intron, sizeof(intron));
-            uart_write_bytes(UART_NUM_0, (const char*)&header, sizeof(header));
+            uart_write_bytes(UART_NUM_0, intron.data(), intron.size());
+            uart_write_bytes(UART_NUM_0, (const char*)&message.header, sizeof(message.header) + sizeof(message.data_checksum));
             uart_write_bytes(UART_NUM_0, (const char*)buff->data, buff->len);
             xSemaphoreGive(uart_mtx);
             // ESP_LOGI(TAG, "Packet UART out done");
@@ -868,7 +848,7 @@ extern "C" void app_main() {
 
     scan.stored_ssids_count = SCAN_MAX_STORED_SSIDS;
     clear_stored_ssids();
-    memset(latest_ssid, 0, SSID_LEN);
+    memset(latest_ssid, 0, esp::SSID_LEN);
     memset(latest_bssid, 0, BSSID_LEN);
 
     ESP_LOGI(TAG, "Wifi init");


### PR DESCRIPTION
* makes the codebase c++ (partially - only to compile)
* prevent sending mac address twice
* use common lib (just header files) with printer to make sure all the names are same on both sides
  * also preparation for merging the code into the main private repo if needed
* calculate and validate checksum for messages (done with the common lib)
  * needed to make some extra changes for esp32, to make the FW more like esp8266 FW
  * only remaining vastly different think is how we send messages from esp32 and esp8266, otherwise we could merge the firmware into one in the future.
* limit some logging to increase the esp speed (mostly during scan)

BFW-5659
BFW-5609
BFW-5662